### PR TITLE
Change trigger from @claude to @paddle

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,10 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@paddle')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@paddle')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@paddle')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@paddle') || contains(github.event.issue.title, '@paddle')))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/test_claude_pr.md
+++ b/test_claude_pr.md
@@ -1,0 +1,3 @@
+# Test file for Claude PR
+
+This is a test file to verify the Claude PR workflow.


### PR DESCRIPTION
## Summary
- 将 workflow 触发关键词从 `@claude` 改为 `@paddle`
- 现在 PR 中使用 `@paddle` 即可触发 Claude Code 响应

## Test plan
- 在 PR 评论中使用 `@paddle` 测试触发
- 验证工作流正常运行

🤖 Generated with [Claude Code](https://claude.com/claude-code)