### PR TITLE
Fix trigger_phrase to use @paddle

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          trigger_phrase: '@paddle'
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary
- 添加 `trigger_phrase: '@paddle'` 参数
- 修复 workflow `if` 条件与 Action 内部 trigger 不一致的问题

## 问题原因
- Workflow 的 `if` 条件已改为 `@paddle`
- 但 Action 内部默认使用 `trigger_phrase: '@claude'`
- 导致评论 `@paddle` 后 workflow 虽然启动，但内部检查失败

## Test plan
- 合并后在 PR 评论中使用 `@paddle` 测试触发

🤖 Generated with [Claude Code](https://claude.com/claude-code)