### PR TITLE
Use self-hosted runner test_paddle for Claude Code workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,7 +18,7 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
-    runs-on: ubuntu-latest
+    runs-on: test_paddle
     permissions:
       contents: read
       pull-requests: read
@@ -41,4 +41,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@paddle')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@paddle')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@paddle') || contains(github.event.issue.title, '@paddle')))
-    runs-on: ubuntu-latest
+    runs-on: test_paddle
     permissions:
       contents: read
       pull-requests: read
@@ -48,4 +48,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-


### PR DESCRIPTION
## Summary
- Changed `runs-on: ubuntu-latest` to `runs-on: test_paddle` in both Claude workflow files
- Workflows now run on self-hosted infrastructure with custom API endpoint

## Changed Files
- `.github/workflows/claude.yml`
- `.github/workflows/claude-code-review.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)