### PR TITLE
Fix: manually install bun to avoid GLIBC issues with setup-bun action

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,21 +3,9 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: test_paddle
     permissions:
       contents: read
@@ -26,6 +14,15 @@ jobs:
       id-token: write
 
     steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '16'
+
+      - name: Install bun manually
+        run: |
+          curl -fsSL https://bun.sh/install | bash
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -39,5 +36,6 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          path_to_bun_executable: ~/.bun/bin/bun
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -23,8 +23,17 @@ jobs:
       pull-requests: read
       issues: read
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read
     steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '16'
+
+      - name: Install bun manually
+        run: |
+          curl -fsSL https://bun.sh/install | bash
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -36,15 +45,8 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           trigger_phrase: '@paddle'
-
-          # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          path_to_bun_executable: ~/.bun/bin/bun
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}


### PR DESCRIPTION
## Summary
- Manually install bun using curl instead of setup-bun action
- setup-bun action requires Node.js 20 which doesn't work with runner's old GLIBC
- Add ANTHROPIC_BASE_URL environment variable for custom API endpoint
- Use self-hosted runner `test_paddle`

## Changes
- `.github/workflows/claude.yml` - Manual bun install
- `.github/workflows/claude-code-review.yml` - Manual bun install

🤖 Generated with [Claude Code](https://claude.com/claude-code)