### PR TITLE
Use self-hosted runner test_paddle with Ubuntu (GLIBC 2.35)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,21 +3,9 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: test_paddle
     permissions:
       contents: read
@@ -39,5 +27,5 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened]
 
 jobs:
   claude-review:
@@ -38,4 +38,3 @@ jobs:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
           BUN_INSTALL_REGISTRY: https://registry.npmmirror.com
           no_proxy: '*'
-          NO_PROXY: '*'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set PATH
+      - name: Setup environment
         run: |
-          export PATH=/home/paddle-1/.bun/bin:$PATH
-          bun --version
+          export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+          echo "PATH=$PATH"
 
       - name: Run Claude Code Review
         id: claude-review
@@ -35,4 +35,3 @@ jobs:
           path_to_bun_executable: /home/paddle-1/.bun/bin/bun
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
-          PATH: /home/paddle-1/.bun/bin:$PATH

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,6 +29,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,3 +35,4 @@ jobs:
           path_to_bun_executable: /home/paddle-1/.bun/bin/bun
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          BUN_INSTALL_REGISTRY: https://registry.npmmirror.com

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,4 +36,3 @@ jobs:
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
           BUN_INSTALL_REGISTRY: https://registry.npmmirror.com
-          no_proxy: '*'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,6 +32,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          path_to_bun_executable: /home/paddle-1/.bun/bin/bun
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
           PATH: /home/paddle-1/.bun/bin:$PATH

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,6 +19,11 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Set PATH
+        run: |
+          export PATH=/home/paddle-1/.bun/bin:$PATH
+          bun --version
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
@@ -29,3 +34,4 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          PATH: /home/paddle-1/.bun/bin:$PATH

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   claude-review:
-    runs-on: test_paddle
+    runs-on: test_paddle_docker
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Setup environment
         run: |
-          export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+          export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.comate/baidu-cc/bin
           echo "PATH=$PATH"
 
       - name: Run Claude Code Review
@@ -32,7 +32,6 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          path_to_bun_executable: /home/paddle-1/.bun/bin/bun
+          path_to_claude_code_executable: /root/.comate/baidu-cc/bin/ducc
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
-          BUN_INSTALL_REGISTRY: https://registry.npmmirror.com

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,6 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened]
 
 jobs:
   claude-review:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,3 +37,5 @@ jobs:
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
           BUN_INSTALL_REGISTRY: https://registry.npmmirror.com
+          no_proxy: '*'
+          NO_PROXY: '*'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,3 +46,4 @@ jobs:
           path_to_bun_executable: /home/paddle-1/.bun/bin/bun
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          BUN_INSTALL_REGISTRY: https://registry.npmmirror.com

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: read
       issues: read
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -36,15 +36,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           trigger_phrase: '@paddle'
-
-          # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,6 +43,7 @@ jobs:
           trigger_phrase: '@paddle'
           additional_permissions: |
             actions: read
+          path_to_bun_executable: /home/paddle-1/.bun/bin/bun
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
           PATH: /home/paddle-1/.bun/bin:$PATH

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,10 +30,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set PATH
+      - name: Setup environment
         run: |
-          export PATH=/home/paddle-1/.bun/bin:$PATH
-          bun --version
+          export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+          echo "PATH=$PATH"
 
       - name: Run Claude Code
         id: claude
@@ -46,4 +46,3 @@ jobs:
           path_to_bun_executable: /home/paddle-1/.bun/bin/bun
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
-          PATH: /home/paddle-1/.bun/bin:$PATH

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -48,3 +48,5 @@ jobs:
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
           BUN_INSTALL_REGISTRY: https://registry.npmmirror.com
+          no_proxy: '*'
+          NO_PROXY: '*'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -48,4 +48,3 @@ jobs:
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
           BUN_INSTALL_REGISTRY: https://registry.npmmirror.com
-          no_proxy: '*'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,6 +40,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           trigger_phrase: '@paddle'
           additional_permissions: |
             actions: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@paddle')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@paddle')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@paddle') || contains(github.event.issue.title, '@paddle')))
-    runs-on: test_paddle
+    runs-on: test_paddle_docker
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,6 +30,11 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Set PATH
+        run: |
+          export PATH=/home/paddle-1/.bun/bin:$PATH
+          bun --version
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -40,3 +45,4 @@ jobs:
             actions: read
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          PATH: /home/paddle-1/.bun/bin:$PATH

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Setup environment
         run: |
-          export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+          export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.comate/baidu-cc/bin
           echo "PATH=$PATH"
 
       - name: Run Claude Code
@@ -44,7 +44,6 @@ jobs:
           trigger_phrase: '@paddle'
           additional_permissions: |
             actions: read
-          path_to_bun_executable: /home/paddle-1/.bun/bin/bun
+          path_to_claude_code_executable: /root/.comate/baidu-cc/bin/ducc
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
-          BUN_INSTALL_REGISTRY: https://registry.npmmirror.com

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -49,4 +49,3 @@ jobs:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
           BUN_INSTALL_REGISTRY: https://registry.npmmirror.com
           no_proxy: '*'
-          NO_PROXY: '*'


### PR DESCRIPTION
## Summary
- Use self-hosted runner `test_paddle` with upgraded Ubuntu (GLIBC 2.35)
- Add ANTHROPIC_BASE_URL environment variable for custom API endpoint
- Remove Node.js and bun installation steps (using pre-installed versions)

## Changes
- `.github/workflows/claude.yml` - Simplified workflow
- `.github/workflows/claude-code-review.yml` - Simplified workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)